### PR TITLE
Updated readme.md for Root CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ python consumer.py
 
 Open another terminal window and `cd` into same directory and run `python producer.py`.
 Send your messages by pressing your system's EOF key sequence. (ctrl-d in bash)
+
+## Adding a Root CA
+
+In some cases the CloudKarafka Root CA may need to be manually added to the example, particularly if you are seeing the error:
+```
+Failed to verify broker certificate: unable to get local issuer certificate 
+```
+returned when you run the example. If this is the case you will need to download the [CloudKarakfa Root CA](https://www.cloudkarafka.com/certs/cloudkarafka.ca) (See also the [FAQ](https://www.cloudkarafka.com/docs/faq.html)) and place it in the python-kafka-example directory, then add the following line into the `conf {...}` section:
+```
+'ssl.ca.location': 'cloudkarafka.ca'
+```
+This should resolve the error and allow for successful connection to the server.


### PR DESCRIPTION
In order to find the root CA in order to get this example working I needed to contact support. Figured it might be helpful to have instructions for anyone running into the:
```
Failed to verify broker certificate: unable to get local issuer certificate
```
error (which I'm running into on both OSX and AWS AMI) built into the readme file.