### PR TITLE
Remove session timeout and default topic config for producer

### DIFF
--- a/producer.py
+++ b/producer.py
@@ -10,8 +10,6 @@ if __name__ == '__main__':
     # See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
     conf = {
         'bootstrap.servers': os.environ['CLOUDKARAFKA_BROKERS'],
-        'session.timeout.ms': 6000,
-        'default.topic.config': {'auto.offset.reset': 'smallest'},
         'security.protocol': 'SASL_SSL',
 	'sasl.mechanisms': 'SCRAM-SHA-256',
         'sasl.username': os.environ['CLOUDKARAFKA_USERNAME'],


### PR DESCRIPTION
With confluent-kafka==1.7.0 and Python 3.9.2 I get the following warnings when running `producer.py`:
```
* Configuration property session.timeout.ms is a consumer property and will be ignored by this producer instance
* Configuration property auto.offset.reset is a consumer property and will be ignored by this producer instance
```
So I removed the aforementioned properties - which caused the warnings to disappear and the rest functions as intended.